### PR TITLE
Using the latest fixed xanderhendriks/action-build-stm32cubeide

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - uses: xanderhendriks/action-build-stm32cubeide@v5.0
+      - uses: xanderhendriks/action-build-stm32cubeide@v7.2
         with:
           project-path: '.'
           project-target: 'SteeringFirmware'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - uses: Solar-Gators/STM32-Infrastructure@main
+      - uses: xanderhendriks/action-build-stm32cubeide@v5.0
         with:
-          project-path: '/github/workspace/'
+          project-path: '.'
           project-target: 'SteeringFirmware'
 
       - uses: actions/upload-artifact@v3


### PR DESCRIPTION
@Seth10001 I saw you already noticed that the github action was unable to build when you were trying to do that in the root of the project (I don't use it that way and hence never tested for this). Thanks to your feedback this has now been fixed.

In this pull request I changed it to use the latest version of the STM32CubeIde. In your [comment](https://github.com/xanderhendriks/action-build-stm32cubeide/issues/3#issuecomment-1292168962) you mentioned that you had to change IDE version to get it to work? I don't quite understand why you say that. It seems to build fine with 1.10.1. Or do you need to stick to 1.8 for another reason?